### PR TITLE
feat: use static build of app with nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,12 @@ FROM base AS deps
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm fetch --frozen-lockfile
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile --prod
 
-FROM base
+FROM deps AS build
 COPY src ./src
 COPY public ./public
-COPY --from=deps /app/node_modules /app/node_modules
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm build
+
+FROM nginx:1.27.5
+COPY nginx/conf.d /etc/nginx/conf.d
+COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 3000
-CMD [ "pnpm", "start" ]

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,29 @@
+server {
+    listen       3000;
+    listen  [::]:3000;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location /api {
+        rewrite ^/api/(.*) /TMI/v1/$1  break;
+        proxy_pass http://192.168.12.1;
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+}


### PR DESCRIPTION
This should allow the app to run with very little memory. My testing shows 4Mib memory instead of 500-600Mib when running the development server.